### PR TITLE
ipad에서 header가 무용지물이 되는 문제

### DIFF
--- a/src/components/desktop-about.module.css
+++ b/src/components/desktop-about.module.css
@@ -5,6 +5,8 @@
   height: 800px;
   color: white;
   overflow: hidden;
+
+  margin-top: calc(-1 * var(--height-top-menu));
 }
 
 .topContentContainer {

--- a/src/components/desktop-header.js
+++ b/src/components/desktop-header.js
@@ -64,7 +64,6 @@ export const DesktopHeader = ({ isFloatMenu, curMenu }) => {
           </ExternalLinkWithQuery>
         </Container1024>
       </header>
-      {!isFloatMenu && <div className={styles.headerPlaceholder}></div>}
     </>
   );
 };

--- a/src/components/desktop-header.module.css
+++ b/src/components/desktop-header.module.css
@@ -3,7 +3,9 @@
   width: 100%;
   height: var(--height-top-menu);
   z-index: 100;
-  position: fixed;
+  position: sticky;
+  top: 0;
+  left: 0;
 }
 
 .headerPlaceholder {

--- a/src/components/desktop-index.module.css
+++ b/src/components/desktop-index.module.css
@@ -5,6 +5,8 @@
   height: 800px;
   color: white;
   overflow: hidden;
+
+  margin-top: calc(-1 * var(--height-top-menu));
 }
 
 .topContentContainer {


### PR DESCRIPTION
- 헤더의 포지션을 fixed에서 sticky로 변경하여 해결하는 케이스
- ie에서 세로 스크롤에 대한 헤더 고정이 안됨.