### PR TITLE
앱 다운로드 버튼 아이폰 인디케이터 영역 채우기

### DIFF
--- a/src/components/mobile-layout.module.css
+++ b/src/components/mobile-layout.module.css
@@ -41,4 +41,9 @@ html:not([lang="ko"]) .mobileLayout {
   right: 0;
 
   box-shadow: none;
+  
+  /* iphone safe area */
+  box-sizing: content-box;
+  padding-bottom: constant(safe-area-inset-bottom);
+  padding-bottom: env(safe-area-inset-bottom);
 }


### PR DESCRIPTION
- [ ] Simple is best
  - 작게 만들어라
  - 한 가지만 해라.
  - 함수 당 추상화 수준은 하나로.
- [ ] UI 레이아웃 보다는 상태를 기준으로 코드를 작성했나. (과도한 분기문 피하기)
- [ ] 이름은 적절히 지었나.
  - 형식 통일 (camelCase, snake_case 혼용 금지)
  - 서술적 이름, 의미없는 접두어/접미어 지양 등
- [ ] 반복하지 마라.

---

아이폰 X 이후 모델에서 하단 인디케이터 부분까지 버튼이 내려가던 현상 수정했습니다.
<img src="https://user-images.githubusercontent.com/52340070/137423603-eeb21802-f7c8-41c3-aba8-605e766dfbcf.png" width=300 />
<img src="https://user-images.githubusercontent.com/52340070/137423631-446316c7-d8dd-4eb7-8b8b-54d851f4dccf.png" width=300 />

기기 테스트가 좀 필요할 것 같습니다
현재 아이폰 13, 아이폰 12, 아이폰 XR, 갤럭시 z 플립에서 실행해봤는데 문제는 없었습니다
다만 아이폰도 어떤 브라우저로 접속하는가에 따라 다른 것 같습니다. (사파리, 크롬에서는 정상 작동)