### PR TITLE
각 페이지의 head에 link rel="alternate" 추가

### DIFF
--- a/src/components/SEOHelmet.jsx
+++ b/src/components/SEOHelmet.jsx
@@ -7,9 +7,9 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { Helmet } from "react-helmet";
 import { useStaticQuery, graphql } from "gatsby";
 import { useI18next } from "gatsby-plugin-react-i18next";
+import WithAlternateLangs from "./WithAlternateLangsHelmet";
 
 function SEOHelmet({
   description, meta, title,
@@ -29,18 +29,6 @@ function SEOHelmet({
             fbAppId
           }
         }
-        allSitePage:
-          allSitePage(filter: {context: {i18n: {routed: {eq: true}}}}) {
-            group(field: context___i18n___originalPath) {
-              fieldValue
-              totalCount
-              nodes {
-                context {
-                  language
-                }
-              }
-            }
-          }
         ogImg: file(relativePath: { eq: "og_image.png" }) {
           publicURL
         }
@@ -48,32 +36,17 @@ function SEOHelmet({
     `,
   );
 
-  const { site, allSitePage: { group: groupByOriginalPath } } = data;
+  const { site } = data;
   const metaDescription = description || site.siteMetadata.description;
   const { siteUrl } = site.siteMetadata;
 
-  const curPathGroup = groupByOriginalPath.find(({ fieldValue }) => fieldValue === originalPath);
-  const allAlternativeLangs = curPathGroup.nodes.map(({ context }) => context.language);
-  const linkProps = allAlternativeLangs.length > 1 && [{
-    rel: "alternate",
-    hrefLang: "x-default",
-    href: `${siteUrl}${originalPath}`,
-  },
-  ...allAlternativeLangs
-    .map(((langCode) => ({
-      rel: "alternate",
-      hrefLang: langCode,
-      href: `${siteUrl}/${langCode}${originalPath}`,
-    })))];
-
   return (
-    <Helmet
+    <WithAlternateLangs
       htmlAttributes={{
         lang: language,
       }}
       title={title}
       titleTemplate={`%s | ${site.siteMetadata.title}`}
-      link={linkProps}
       meta={[
         {
           name: "description",

--- a/src/components/WithAlternateLangsHelmet.jsx
+++ b/src/components/WithAlternateLangsHelmet.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Helmet } from "react-helmet";
+import { useStaticQuery, graphql } from "gatsby";
+import { useI18next } from "gatsby-plugin-react-i18next";
+
+const WithAlternateLangs = (props) => {
+  const { children } = props;
+
+  const {
+    defaultLanguage, language, originalPath, siteUrl = "",
+  } = useI18next();
+  const data = useStaticQuery(
+    graphql`
+      query AllSite {
+        allSitePage:
+          allSitePage(filter: {context: {i18n: {routed: {eq: true}}}}) {
+            group(field: context___i18n___originalPath) {
+              fieldValue
+              totalCount
+              nodes {
+                context {
+                  language
+                }
+              }
+            }
+          }
+      }
+    `,
+  );
+
+  const { allSitePage: { group: groupByOriginalPath } } = data;
+
+  const createUrlWithLang = (lng) => {
+    const url = `${siteUrl}/${lng}${originalPath}`;
+    return url.endsWith("/") ? url : `${url}/`;
+  };
+  const curPathGroup = groupByOriginalPath.find(({ fieldValue }) => fieldValue === originalPath);
+  const allAlternativeLangs = curPathGroup.nodes.map(({ context }) => context.language);
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Helmet {...props}>
+      <link
+        rel="canonical"
+        href={createUrlWithLang(language)}
+      />
+      {allAlternativeLangs.map((lng) => (
+        <link
+          rel="alternate"
+          key={lng}
+          href={createUrlWithLang(lng)}
+          hrefLang={lng}
+        />
+      ))}
+      <link
+        rel="alternate"
+        href={createUrlWithLang(defaultLanguage)}
+        hrefLang="x-default"
+      />
+      {children}
+    </Helmet>
+  );
+};
+
+export default WithAlternateLangs;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -8,16 +8,14 @@ import MobileLayout from "../components/mobile-layout";
 import { Media } from "../media";
 import SEOHelmet from "../components/SEOHelmet";
 
-const NotFoundPage = ({ data, location }) => {
-  const { language, t } = useI18next();
+const NotFoundPage = ({ data }) => {
+  const { t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title="NOT FOUND"
         description="NOT FOUND"
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -8,16 +8,14 @@ import DesktopAbout from "../components/desktop-about";
 import MobileAbout from "../components/mobile-about";
 import { useHelpscout } from "../components/helpscout";
 
-const AboutPage = ({ data, location }) => {
+const AboutPage = ({ data }) => {
   const { language, t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("about:pageTitle")}
         description={t("about:pageDescription")}
-        path={location.pathname}
       />
       <Media at="xs">
         <MobileAbout

--- a/src/pages/features.js
+++ b/src/pages/features.js
@@ -8,16 +8,16 @@ import DesktopFeatures from "../components/desktop-features";
 import MobileFeatures from "../components/mobile-features";
 import { useHelpscout } from "../components/helpscout";
 
-export default function FeaturesPage({ data, location }) {
-  const { language, t } = useI18next();
+export default function FeaturesPage({ data }) {
+  const {
+    language, t,
+  } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("features:pageTitle")}
         description={t("features:pageDescription")}
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,16 +8,14 @@ import DesktopIndex from "../components/desktop-index";
 import MobileIndex from "../components/mobile-index";
 import { useHelpscout } from "../components/helpscout";
 
-const IndexPage = ({ data, location }) => {
+const IndexPage = ({ data }) => {
   const { language, t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("index:pageTitle")}
         description={t("index:pageDescription")}
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/pages/marketing-210524.js
+++ b/src/pages/marketing-210524.js
@@ -6,16 +6,14 @@ import SEOHelmet from "../components/SEOHelmet";
 import MobileMarketing from "../components/mobile-marketing-210524";
 import { useHelpscout } from "../components/helpscout";
 
-const MarketingPage = ({ data, location }) => {
-  const { language, t } = useI18next();
+const MarketingPage = ({ data }) => {
+  const { t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("index:pageTitle")}
         description={t("index:pageDescription")}
-        path={location.pathname}
       />
       <MobileMarketing data={data} />
     </>

--- a/src/pages/marketing-210630.js
+++ b/src/pages/marketing-210630.js
@@ -8,16 +8,14 @@ import { ExternalLinkWithQuery } from "../components/common";
 import { useHelpscout } from "../components/helpscout";
 import { urlStart } from "../components/constants";
 
-const MarketingPage = ({ data, location }) => {
-  const { language, t } = useI18next();
+const MarketingPage = ({ data }) => {
+  const { t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("index:pageTitle")}
         description={t("index:pageDescription")}
-        path={location.pathname}
       />
       <div style={{ maxWidth: 960, margin: "0 auto" }}>
         <GatsbyImage image={data.mobile1.childImageSharp.gatsbyImageData} />

--- a/src/pages/marketing.js
+++ b/src/pages/marketing.js
@@ -9,16 +9,14 @@ import DesktopMarketingEn from "../components/desktop-marketing-en";
 import MobileMarketing from "../components/mobile-marketing";
 import { useHelpscout } from "../components/helpscout";
 
-const MarketingPage = ({ data, location }) => {
+const MarketingPage = ({ data }) => {
   const { language, t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("index:pageTitle")}
         description={t("index:pageDescription")}
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -8,16 +8,14 @@ import DesktopPricing from "../components/desktop-pricing";
 import MobilePricing from "../components/mobile-pricing";
 import { useHelpscout } from "../components/helpscout";
 
-export default function PricingPage({ data, location }) {
+export default function PricingPage({ data }) {
   const { language, t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("pricing:pageTitle")}
         description={t("pricing:pageDescription")}
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/pages/usecase-assets.js
+++ b/src/pages/usecase-assets.js
@@ -8,16 +8,14 @@ import DesktopUsecaseAssets from "../components/desktop-usecase-assets";
 import MobileUsecaseAssets from "../components/mobile-usecase-assets";
 import { useHelpscout } from "../components/helpscout";
 
-export default function UsecaseAssetsPage({ data, location }) {
+export default function UsecaseAssetsPage({ data }) {
   const { language, t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("usecase:pageTitle")}
         description={t("usecase:pageDescription")}
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/pages/usecase-material.js
+++ b/src/pages/usecase-material.js
@@ -8,16 +8,14 @@ import DesktopUsecaseMaterial from "../components/desktop-usecase-material";
 import MobileUsecaseMaterial from "../components/mobile-usecase-material";
 import { useHelpscout } from "../components/helpscout";
 
-export default function UsecaseMaterialPage({ data, location }) {
+export default function UsecaseMaterialPage({ data }) {
   const { language, t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("usecase:pageTitle")}
         description={t("usecase:pageDescription")}
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/pages/usecase-sales.js
+++ b/src/pages/usecase-sales.js
@@ -8,16 +8,14 @@ import DesktopUsecaseSales from "../components/desktop-usecase-sales";
 import MobileUsecaseSales from "../components/mobile-usecase-sales";
 import { useHelpscout } from "../components/helpscout";
 
-export default function UsecaseSalesPage({ data, location }) {
+export default function UsecaseSalesPage({ data }) {
   const { language, t } = useI18next();
   useHelpscout();
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("usecase:pageTitle")}
         description={t("usecase:pageDescription")}
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/templates/PostList.jsx
+++ b/src/templates/PostList.jsx
@@ -8,9 +8,9 @@ import SEOHelmet from "../components/SEOHelmet";
 import PostListDesktop from "../components/desktop-postlist";
 import PostListMobile from "../components/mobile-postlist";
 
-export default function PostList({ pageContext, location, data }) {
+export default function PostList({ pageContext, data }) {
   const { pageIndex, lastPageIndex } = pageContext;
-  const { language, t } = useI18next();
+  const { t } = useI18next();
   const {
     allMarkdownRemark: { edges },
   } = data;
@@ -18,10 +18,8 @@ export default function PostList({ pageContext, location, data }) {
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("blog:pageTitle")}
         description={t("blog:pageDescription")}
-        path={location.pathname}
       />
 
       <Media at="xs">

--- a/src/templates/PostView.jsx
+++ b/src/templates/PostView.jsx
@@ -7,8 +7,8 @@ import SEOHelmet from "../components/SEOHelmet";
 import PostViewDesktop from "../components/desktop-postview";
 import PostViewMobile from "../components/mobile-postview";
 
-export default function PostView({ data, location }) {
-  const { t, language } = useI18next();
+export default function PostView({ data }) {
+  const { t } = useI18next();
   const { currentPostData, prevPostData, nextPostData } = data;
   const {
     frontmatter: { title, description },
@@ -17,12 +17,10 @@ export default function PostView({ data, location }) {
   return (
     <>
       <SEOHelmet
-        lang={language}
         title={t("blog:postviewTitle", {
           title,
         })}
         description={description}
-        path={location.pathname}
       />
 
       <Media at="xs">


### PR DESCRIPTION
## 연관 이슈
- 한국어 페이지는 있는데 영어 페이지가 없는 경우가 있다.
  - ex 1 : 한국어는 블로그 페이지가 3 페이지까지 있는데 영어는 1페이지밖에 없다.
  - ex 2 : 각 블로그 게시물은 언어별 대체 페이지가 없다.
  - ex 3 : 마케팅 페이지와 같이 대체 페이지가 아예 존재하지 않는 경우. 